### PR TITLE
fix symbol naming bug missed in tests

### DIFF
--- a/src/GraphDataFrameBridge.jl
+++ b/src/GraphDataFrameBridge.jl
@@ -119,7 +119,7 @@ function metagraph_from_dataframe(graph_type,
         edge_attributes = Vector{Symbol}([edge_attributes])
     end
 
-    origin_id = Symbol(start, :_id)
+    origin_id = Symbol(origin, :_id)
     destination_id = Symbol(destination, :_id)
 
     for e in edge_attributes

--- a/test/graphdataframebridge.jl
+++ b/test/graphdataframebridge.jl
@@ -36,4 +36,21 @@ importall GraphDataFrameBridge
     @test get_prop(mg, Edge(1, 2), :weight) == 1
     @test get_prop(mg, Edge(4, 5), :weight) == 4
     @test get_prop(mg, Edge(4, 5), :extras) == 8
+
+
+    # Test with different column names to ensure nothing name sensitive
+    df2 = DataFrame(Dict("alice" => ["a", "b", "a", "d"],
+                        "bob" => ["b", "c", "e", "e"],
+                        "weightz" => 1:4,
+                        "extraz" => 5:8))
+
+    mg = MetaGraph(df2, :alice, :bob,
+             weight=:weightz,
+             edge_attributes=:extraz)
+    @test length(neighbors(mg, 2)) == 2
+    @test get_prop(mg, Edge(1, 2), :weight) == 1
+    @test get_prop(mg, Edge(4, 5), :weight) == 4
+    @test get_prop(mg, Edge(4, 5), :extraz) == 8
+
+
 end


### PR DESCRIPTION
Tests used a dataframe whose origin column was named `start`, and that allowed an error to slip through (it worked if column named `start` but not anything else). This fixes bug and adds test. 