### PR TITLE
Fixes to deprecated DataFrames syntax and inclusion of separate vertex information

### DIFF
--- a/src/GraphDataFrameBridge.jl
+++ b/src/GraphDataFrameBridge.jl
@@ -89,12 +89,12 @@ function metagraph_from_dataframe(graph_type,
                                   edge_attributes::Union{Vector{Symbol}, Symbol}=Vector{Symbol}())
 
     # Map node names to vertex IDs
-    nodes = [df[origin]; df[destination]]
+    nodes = [df[!, origin]; df[!, destination]]
     nodes = unique(nodes)
     sort!(nodes)
 
     vertex_names = DataFrame(Dict(:name => nodes))
-    vertex_names[:vertex_id] = Base.OneTo(nrow(vertex_names))
+    vertex_names[!, :vertex_id] = Base.OneTo(nrow(vertex_names))
 
     # Merge in to original
     for c in [origin, destination]

--- a/test/graphdataframebridge.jl
+++ b/test/graphdataframebridge.jl
@@ -50,8 +50,43 @@
     @test get_prop(mg, Edge(4, 5), :weight) == 4
     @test get_prop(mg, Edge(4, 5), :extraz) == 8
 
+    # Test with additional vertex information
+    attribs = DataFrame(
+        name = ["a", "b", "c", "d", "e"],
+        age = [25, 30, 40, 65, 40],
+        class = ["L", "L", "M", "S", "P"]
+    )
+    @inferred (MetaGraph(df, :start, :finish,
+                   weight=:weights,
+                   edge_attributes=:extras,
+                   vertex_attributes=attribs))
+
+   @inferred (MetaGraph(df, :start, :finish,
+                  weight=:weights,
+                  edge_attributes=:extras,
+                  vertex_attributes=attribs,
+                  vertex_id_col = :name))
+
+    mg = MetaGraph(df, :start, :finish,
+                   weight=:weights,
+                   edge_attributes=:extras,
+                   vertex_attributes=attribs,
+                   vertex_id_col=:name)
+
+   @test length(neighbors(mg, 2)) == 2
+   @test get_prop(mg, Edge(1, 2), :weight) == 1
+   @test get_prop(mg, Edge(4, 5), :weight) == 4
+   @test get_prop(mg, Edge(4, 5), :extras) == 8
+
+   @test get_prop(mg, 1, :name) == "a"
+   @test get_prop(mg, 2, :name) == "b"
+   @test get_prop(mg, 1, :age) == 25
+   @test get_prop(mg, 2, :age) == 30
+   @test get_prop(mg, 3, :class) == "M"
+   @test get_prop(mg, 4, :class) == "S"
+
     # Test name column is indexed (Issue #9)
     @test mg["a", :name] == 1
     @test mg["b", :name] == 2
-    
+
 end


### PR DESCRIPTION
This (a) fixes warnings about deprecated DataFrames indexing syntax when creating a MetaGraph and (b) adds functionality to include additional vertex information stored in a separate DataFrame.