### PR TITLE
Fix deprecation warnings and errors with DataFrames v0.21.0

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -8,10 +8,10 @@ LightGraphs = "093fc24a-ae57-5d10-9952-331d41423f4d"
 MetaGraphs = "626554b9-1ddb-594c-aa3c-2596fe9399a5"
 
 [compat]
-DataFrames = "0.20, 0.21, 0.22, 0.23"
+DataFrames = "0.21"
 LightGraphs = "1"
-julia = "1"
 MetaGraphs = "0.6.3, 2.0.0"
+julia = "1"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"


### PR DESCRIPTION
Closes #15, closes #16.

Note: With this PR GraphDataFrameBridge.jl becomes incompatible with older DataFrames.jl versions. I updated the `Project.toml` accordingly. Also, I removed compatibility with newer versions with `DataFrames.jl` (i.e. versions that are not even published yet) since they might introduce other breaking changes which should not affect GraphDataFrameBridge.jl releases.