### PR TITLE
Construct DataFrame from MetaGraph?

### DIFF
--- a/src/DataFrame.jl
+++ b/src/DataFrame.jl
@@ -4,6 +4,9 @@ import DataFrames.DataFrame
     DataFrame(gr::T; type = :node) where T <:AbstractMetaGraph
 
 Construct a DataFrame from a MetaGraph from either its node or edge properties.
+`gr` is a MetaGraph.
+`type` is a Symbol valued either :node or :edge such that the DataFrame is populated with node or edge
+properties stored in `gr`.
 """
 function DataFrame(gr::T; type = :node) where T <:AbstractMetaGraph
     fl, prps, en, nu = if type == :node

--- a/src/DataFrame.jl
+++ b/src/DataFrame.jl
@@ -14,7 +14,7 @@ function DataFrame(gr::T; type = :node) where T <:AbstractMetaGraph
     elseif type == :edge
         :edge => Edge[], gr.eprops, edges, ne
       else
-        error("specify :node or :edge")
+        error("specify type equal to :node or :edge")
     end
 
     dx = DataFrame(fl)

--- a/src/DataFrame.jl
+++ b/src/DataFrame.jl
@@ -4,9 +4,11 @@ import DataFrames.DataFrame
     DataFrame(gr::T; type = :node) where T <:AbstractMetaGraph
 
 Construct a DataFrame from a MetaGraph from either its node or edge properties.
+
 `gr` is a MetaGraph.
 `type` is a Symbol valued either :node or :edge such that the DataFrame is populated with node or edge
 properties stored in `gr`.
+
 """
 function DataFrame(gr::T; type = :node) where T <:AbstractMetaGraph
     fl, prps, en, nu = if type == :node

--- a/src/DataFrame.jl
+++ b/src/DataFrame.jl
@@ -1,0 +1,44 @@
+import DataFrames.DataFrame
+
+"""
+    DataFrame(gr::T; type = :node) where T <:AbstractMetaGraph
+
+Construct a DataFrame from a MetaGraph from either its node or edge properties.
+"""
+function DataFrame(gr::T; type = :node) where T <:AbstractMetaGraph
+    fl, prps, en, nu = if type == :node
+        :node => Int[], gr.vprops, vertices, nv
+    elseif type == :edge
+        :edge => Edge[], gr.eprops, edges, ne
+      else
+        error("specify :node or :edge")
+    end
+
+    dx = DataFrame(fl)
+
+    x = unique(reduce(vcat, values(prps)))
+    for y in x
+        for (k, v) in y
+            dx[!, k] = typeof(v)[] # may be a problem if type is not consistent in y?
+            allowmissing!(dx, k)
+        end
+    end
+    
+    dx = similar(dx, nu(gr))
+
+    for (i, e) in (enumerate∘en)(gr)
+        dx[i, type] = e
+        pr = props(gr, e)
+        for (nme, val) in pr
+            dx[i, nme] = val
+        end
+    end
+
+    # remove missing when possible
+    for v in Symbol.(names(dx))
+        if !any(ismissing.(dx[!, v]))
+            disallowmissing!(dx, v)
+        end
+    end
+    return dx
+end

--- a/src/DataFrame.jl
+++ b/src/DataFrame.jl
@@ -6,8 +6,11 @@ import DataFrames.DataFrame
 Construct a DataFrame from a MetaGraph from either its node or edge properties.
 
 `gr` is a MetaGraph.
+
+Optional keyword arguments:
+
 `type` is a Symbol valued either :node or :edge such that the DataFrame is populated with node or edge
-properties stored in `gr`.
+properties stored in `gr`. Default is :node.
 
 """
 function DataFrame(gr::T; type = :node) where T <:AbstractMetaGraph

--- a/src/GraphDataFrameBridge.jl
+++ b/src/GraphDataFrameBridge.jl
@@ -7,6 +7,8 @@ export MetaGraph, MetaDiGraph
 import MetaGraphs.MetaGraph
 import MetaGraphs.MetaDiGraph
 
+include("DataFrame.jl")
+export DataFrame
 
 function MetaGraph(
     df::T,


### PR DESCRIPTION
Hello,

I thought that it _might_ be useful to have a function that constructs a DataFrame directly from a MetaGraph object, for either its node or edge properties. I have the functions in [tidygraph](https://tidygraph.data-imaginist.com) in mind.

I think that these are practically useful, but do let me know if this is (not) compelling.